### PR TITLE
fix: return tag_value if no value_key

### DIFF
--- a/acapy_wallet_upgrade/strategies.py
+++ b/acapy_wallet_upgrade/strategies.py
@@ -124,7 +124,9 @@ class Strategy(ABC):
         for tag in tags.split(","):
             tag_name, tag_value = map(bytes.fromhex, tag.split(":"))
             name = self.decrypt_merged(tag_name, name_key)
-            value = self.decrypt_merged(tag_value, value_key) if value_key else tag[1]
+            value = (
+                self.decrypt_merged(tag_value, value_key) if value_key else tag_value
+            )
             yield name, value
 
     def decrypt_item(self, row: tuple, keys: dict, b64: bool = False):


### PR DESCRIPTION
This fixes what seems to have been a bug in the handling of plaintext tags.

@andrewwhitehead this line was one we happened to inherit :slightly_smiling_face: I believe these changes captured the intended function of this method but a double check from you would be appreciated, if you get a chance.

Plaintext tags are not well used (I don't think they're used at all in ACA-Py) which let this bug slip past our testing which operates exclusively on ACA-Py wallets.

@blu3beri this also relates to a `TODO` line I noticed in https://github.com/hyperledger/aries-askar/pull/104 where you asked what `tag[1]` represented. I wasn't sure which lead to the discovery of this bug :slightly_smiling_face: 